### PR TITLE
Update pagination information

### DIFF
--- a/src/lib/components/Table/TableContent.svelte
+++ b/src/lib/components/Table/TableContent.svelte
@@ -48,7 +48,7 @@
 		toggle = false, // Whether to display the fitToScreen toggle
 		search = true, // Whether to display the search input
 		pageSizes = [5, 10, 20, 50, 100], // Page sizes to display in the pagination component
-		pageIndexStringType = 'pages', // pages by default
+		pageIndexStringType = 'items', // items by default
 		fitToScreen = true, // Whether to fit the table to the screen,
 		exportable = false, // Whether to display the export button and enable export functionality
 		server

--- a/src/lib/components/Table/TablePagination.svelte
+++ b/src/lib/components/Table/TablePagination.svelte
@@ -62,7 +62,7 @@
 	$: goToNextPageDisabled = !$hasNextPage;
 	$: goToPreviousPageDisabled = !$hasPreviousPage;
 	$: $pageSize = pageSizeDropdownValue;
-	$: $pageCount, $pageIndex, $pageSize, (indexInformation = getIndexInfomationString());
+	$: $pageCount, $pageIndex, $pageSize, itemCount, (indexInformation = getIndexInfomationString());
 </script>
 
 <div class="flex justify-between w-full items-stretch gap-10">

--- a/src/routes/components/table/data/codeBlocks.ts
+++ b/src/routes/components/table/data/codeBlocks.ts
@@ -214,7 +214,7 @@ export interface TableConfig<T> {
 	exportable?: boolean; // false by default
 	pageSizes?: number[]; // [5, 10, 20, 50, 100] by default
 	defaultPageSize?: number; // 10 by default
-	pageIndexStringType?: 'items' | 'pages'; // pages by default
+	pageIndexStringType?: 'items' | 'pages'; // items by default
 	optionsComponent?: typeof SvelteComponent;
 
 	server?: ServerConfig;

--- a/src/routes/components/table/docs/TableConfigDocs.svelte
+++ b/src/routes/components/table/docs/TableConfigDocs.svelte
@@ -199,7 +199,7 @@
 		<p class="text-xl pl-10">
 			Whether the table should display page index information by number of items or pages. <code
 				class="!text-xl bg-tertiary-300 dark:bg-tertiary-700/50 rounded-md p-0.5 text-primary-500"
-				>"pages"</code
+				>"items"</code
 			>
 			by default.
 		</p>


### PR DESCRIPTION
- Fixes the issue with updating the number of displayed items correctly.
- Makes "items" the default type for displaying pagination info.